### PR TITLE
fix(auth): resolve multi-browser login error when sending magic link

### DIFF
--- a/app/login/LoginForm.tsx
+++ b/app/login/LoginForm.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useActionState } from "react";
+import { loginAction } from "./actions";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import SubmitButton from "@/components/submit-button/SubmitButton";
+
+export function LoginForm() {
+  const [error, formAction, isPending] = useActionState(loginAction, undefined);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-2">
+        <Label>Email</Label>
+        <Input
+          name="email"
+          type="email"
+          required
+          placeholder="hello@hello.com"
+        />
+      </div>
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <SubmitButton text="Login" isLoading={isPending} />
+    </form>
+  );
+}

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { signIn } from "@/lib/auth";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
+
+export async function loginAction(
+  _prevState: string | undefined,
+  formData: FormData
+): Promise<string | undefined> {
+  try {
+    await signIn("nodemailer", formData);
+  } catch (error) {
+    if (isRedirectError(error)) throw error;
+    return "Failed to send the magic link. Please try again.";
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,10 +7,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { auth, signIn } from "@/lib/auth";
-import SubmitButton from "@/components/submit-button/SubmitButton";
+import { auth } from "@/lib/auth";
+import { LoginForm } from "./LoginForm";
 
 const LoginPage = async () => {
   const session = await auth();
@@ -32,24 +30,7 @@ const LoginPage = async () => {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <form
-              action={async (formData) => {
-                "use server";
-                await signIn("nodemailer", formData);
-              }}
-              className="flex flex-col gap-y-4"
-            >
-              <div className="flex flex-col gap-y-2">
-                <Label>Email</Label>
-                <Input
-                  name="email"
-                  type="email"
-                  required
-                  placeholder="hello@hello.com"
-                />
-              </div>
-              <SubmitButton text="Login" />
-            </form>
+            <LoginForm />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary

- Fixes multi-browser login showing an error page while sending a magic link
- In NextAuth v5 beta.25, calling `signIn("nodemailer")` in an inline server action causes its internal `NEXT_REDIRECT` error to be intercepted in certain edge cases (e.g. existing DB tokens for the same email), redirecting to `/auth/error` even though the verification email was already sent
- Extracted the form into a client component using `useActionState` and wrapped the `signIn` call with an `isRedirectError` guard so redirect errors always propagate to Next.js correctly, while actual failures surface as an inline form error instead of bouncing to the generic error page

## Test plan
- [ ] Log in from two different browsers with the same email — both should receive the magic link without seeing an error page
- [ ] A genuine auth failure (e.g. invalid email) should show an inline error, not redirect to `/auth/error`

---
_Generated by [Claude Code](https://claude.ai/code/session_017VsM5HNXZWWrvAff4XQxjX)_