### PR TITLE
Align recurring invoice form layout with new invoice form

### DIFF
--- a/app/actions/recurringInvoices.ts
+++ b/app/actions/recurringInvoices.ts
@@ -4,6 +4,8 @@ import { addMonths, addQuarters, addYears } from "date-fns";
 import { parseWithZod } from "@conform-to/zod";
 import { SubmissionResult } from "@conform-to/react";
 
+import { revalidatePath } from "next/cache";
+
 import { getRequiredUserId } from "@/lib/session";
 import { recurringInvoiceSchema } from "@/lib/zodSchemas";
 import { PLAN_FEATURES } from "@/lib/plans";
@@ -57,6 +59,7 @@ export async function createRecurringInvoice(
       },
     });
 
+    revalidatePath("/dashboard/recurring-invoices");
     return { status: "success", error: {} };
   } catch {
     return { status: "error", error: { "": ["Failed to create recurring invoice"] } };

--- a/app/actions/recurringInvoices.ts
+++ b/app/actions/recurringInvoices.ts
@@ -58,12 +58,13 @@ export async function createRecurringInvoice(
         ...rest,
       },
     });
-
-    revalidatePath("/dashboard/recurring-invoices");
-    return { status: "success", error: {} };
-  } catch {
+  } catch (error) {
+    console.error("Failed to create recurring invoice:", error);
     return { status: "error", error: { "": ["Failed to create recurring invoice"] } };
   }
+
+  revalidatePath("/dashboard/recurring-invoices");
+  return { status: "success", error: {} };
 }
 
 export async function toggleRecurringInvoice(id: string) {

--- a/components/invoice-form/InvoiceForm.tsx
+++ b/components/invoice-form/InvoiceForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { Prisma, Client } from "@prisma/client";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import debounce from "lodash/debounce";
 import * as z from "zod";
 
@@ -124,15 +124,13 @@ export function InvoiceForm({
 
   const currency = form.watch("currency") as Currency;
 
-  const updateTotal = useMemo(
-    () =>
-      debounce((quantity: number, rate: number) => {
-        const calculatedTotal = Math.round(quantity * rate * 100) / 100;
-        setLocalTotal(calculatedTotal);
-        form.setValue("total", calculatedTotal, { shouldValidate: true });
-      }, 300),
-    [form]
-  );
+  const updateTotal = useRef(
+    debounce((quantity: number, rate: number) => {
+      const calculatedTotal = Math.round(quantity * rate * 100) / 100;
+      setLocalTotal(calculatedTotal);
+      form.setValue("total", calculatedTotal, { shouldValidate: true });
+    }, 300)
+  ).current;
 
   useEffect(() => {
     const subscription = form.watch((value, { name }) => {
@@ -146,12 +144,15 @@ export function InvoiceForm({
       subscription.unsubscribe();
       updateTotal.cancel();
     };
-  }, [form, updateTotal]);
+  }, [form]);
 
   useEffect(() => {
     const quantity = form.getValues("invoiceItemQuantity") || 0;
     const rate = form.getValues("invoiceItemRate") || 0;
-    updateTotal(quantity, rate);
+    const calculatedTotal = Math.round(quantity * rate * 100) / 100;
+    setLocalTotal(calculatedTotal);
+    form.setValue("total", calculatedTotal, { shouldValidate: false });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function onSubmit(formData: InvoiceFormValues) {

--- a/components/recurring-invoice-dialog/RecurringInvoiceDialog.tsx
+++ b/components/recurring-invoice-dialog/RecurringInvoiceDialog.tsx
@@ -28,7 +28,7 @@ export function RecurringInvoiceDialog({
       <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger}
       </DialogTrigger>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>New Recurring Invoice</DialogTitle>
           <DialogDescription>
@@ -39,6 +39,7 @@ export function RecurringInvoiceDialog({
         <RecurringInvoiceForm
           clients={clients}
           onSuccess={() => setOpen(false)}
+          onClose={() => setOpen(false)}
         />
       </DialogContent>
     </Dialog>

--- a/components/recurring-invoice-dialog/RecurringInvoiceDialog.tsx
+++ b/components/recurring-invoice-dialog/RecurringInvoiceDialog.tsx
@@ -28,7 +28,11 @@ export function RecurringInvoiceDialog({
       <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger}
       </DialogTrigger>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-4xl max-h-[90vh] overflow-y-auto"
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>New Recurring Invoice</DialogTitle>
           <DialogDescription>

--- a/components/recurring-invoice-form/RecurringInvoiceForm.tsx
+++ b/components/recurring-invoice-form/RecurringInvoiceForm.tsx
@@ -1,14 +1,21 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { Client } from "@prisma/client";
+import { useState, useEffect, useMemo } from "react";
+import debounce from "lodash/debounce";
+import { CalendarIcon } from "lucide-react";
+import { format } from "date-fns";
 import * as z from "zod";
 
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Form,
   FormControl,
@@ -24,38 +31,49 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
 import { CurrencySelect } from "@/components/ui/currency-select";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import SubmitButton from "@/components/submit-button/SubmitButton";
 import { recurringInvoiceSchema } from "@/lib/zodSchemas";
 import { createRecurringInvoice } from "@/app/actions/recurringInvoices";
 import { useUser } from "@/components/providers/UserProvider";
+import { toFormData } from "@/lib/toFormData";
+import { formatCurrency } from "@/lib/formatCurrency";
+import { Currency } from "@/types";
 
 type FormValues = z.infer<typeof recurringInvoiceSchema>;
 
 interface RecurringInvoiceFormProps {
   clients: Client[];
   onSuccess?: () => void;
+  onClose?: () => void;
 }
 
 export function RecurringInvoiceForm({
   clients,
   onSuccess,
+  onClose,
 }: RecurringInvoiceFormProps) {
-  const { firstName, lastName, email, companyName, companyEmail, companyAddress, address } = useUser();
-  const defaultFromName = companyName || `${firstName} ${lastName}`.trim();
-  const defaultFromEmail = companyEmail || email;
-  const defaultFromAddress = companyAddress || address;
-
-  const [state, action, isPending] = useActionState(createRecurringInvoice, undefined);
+  const { firstName, lastName, email, companyName, companyEmail, companyAddress, address } =
+    useUser();
+  const [isLoading, setIsLoading] = useState(false);
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+  const [localTotal, setLocalTotal] = useState(0);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(recurringInvoiceSchema),
     defaultValues: {
       interval: "MONTHLY",
       invoiceName: "",
-      fromName: defaultFromName,
-      fromEmail: defaultFromEmail,
-      fromAddress: defaultFromAddress,
+      fromName: companyName || `${firstName} ${lastName}`.trim(),
+      fromEmail: companyEmail || email || "",
+      fromAddress: companyAddress || address || "",
       clientId: "",
       currency: "USD",
       dueDate: 30,
@@ -67,287 +85,503 @@ export function RecurringInvoiceForm({
     },
   });
 
+  const clientId = form.watch("clientId");
+  const selectedClient = clients.find((c) => c.id === clientId) ?? null;
+
+  const currency = form.watch("currency") as Currency;
+
+  const updateTotal = useMemo(
+    () =>
+      debounce((quantity: number, rate: number) => {
+        const calculatedTotal = Math.round(quantity * rate * 100) / 100;
+        setLocalTotal(calculatedTotal);
+        form.setValue("total", calculatedTotal, { shouldValidate: true });
+      }, 300),
+    [form]
+  );
+
   useEffect(() => {
-    if (state?.status === "success") {
+    const subscription = form.watch((_, { name }) => {
+      if (name === "invoiceItemQuantity" || name === "invoiceItemRate") {
+        const quantity = form.getValues("invoiceItemQuantity") || 0;
+        const rate = form.getValues("invoiceItemRate") || 0;
+        updateTotal(quantity, rate);
+      }
+    });
+    return () => {
+      subscription.unsubscribe();
+      updateTotal.cancel();
+    };
+  }, [form, updateTotal]);
+
+  async function onSubmit(values: FormValues) {
+    try {
+      setIsLoading(true);
+      const submitFormData = toFormData(values as Record<string, unknown>);
+      const result = await createRecurringInvoice(null, submitFormData);
+
+      if (result.status === "error") {
+        const msgs = Object.values(result.error ?? {}).flat();
+        toast.error(msgs[0] ?? "Failed to create recurring invoice");
+        return;
+      }
+
       toast.success("Recurring invoice created");
       onSuccess?.();
-    } else if (state?.status === "error") {
-      const msg = Object.values(state.error ?? {}).flat()[0];
-      toast.error(msg ?? "Failed to create recurring invoice");
+      onClose?.();
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to create recurring invoice");
+    } finally {
+      setIsLoading(false);
     }
-  }, [state, onSuccess]);
-
-  const qty = form.watch("invoiceItemQuantity");
-  const rate = form.watch("invoiceItemRate");
-  useEffect(() => {
-    form.setValue("total", Math.round((qty || 0) * (rate || 0) * 100) / 100);
-  }, [qty, rate, form]);
+  }
 
   return (
-    <Form {...form}>
-      <form action={action} className="space-y-4">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="invoiceName"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Invoice Name</FormLabel>
-                <FormControl>
-                  <Input placeholder="Monthly subscription" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="interval"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Recurrence</FormLabel>
-                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select interval" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="MONTHLY">Monthly</SelectItem>
-                    <SelectItem value="QUARTERLY">Quarterly</SelectItem>
-                    <SelectItem value="YEARLY">Yearly</SelectItem>
-                  </SelectContent>
-                </Select>
-                <input type="hidden" name="interval" value={field.value} />
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+    <Card className="w-full">
+      <CardContent className="p-4 sm:p-6">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+            {/* Badge + invoice name */}
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3 mb-6">
+              <Badge variant="secondary" className="w-fit">
+                Recurring
+              </Badge>
+              <FormField
+                control={form.control}
+                name="invoiceName"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormControl>
+                      <Input
+                        placeholder="Enter invoice name"
+                        className="w-full"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="startDate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Start Date</FormLabel>
-                <FormControl>
-                  <Input type="date" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="endDate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>End Date (optional)</FormLabel>
-                <FormControl>
-                  <Input type="date" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+            {/* Recurrence, currency, start date */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+              <FormField
+                control={form.control}
+                name="interval"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Recurrence</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select interval" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="MONTHLY">Monthly</SelectItem>
+                        <SelectItem value="QUARTERLY">Quarterly</SelectItem>
+                        <SelectItem value="YEARLY">Yearly</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="fromName"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Your Name</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="fromEmail"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Your Email</FormLabel>
-                <FormControl>
-                  <Input type="email" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+              <FormField
+                control={form.control}
+                name="currency"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Currency</FormLabel>
+                    <CurrencySelect
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    />
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-        <FormField
-          control={form.control}
-          name="fromAddress"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Your Address</FormLabel>
-              <FormControl>
-                <Input {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+              <FormField
+                control={form.control}
+                name="startDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Start Date</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className="w-full text-left justify-start"
+                          >
+                            <CalendarIcon className="mr-2 size-4" />
+                            {field.value ? (
+                              format(new Date(field.value + "T12:00:00"), "PPP")
+                            ) : (
+                              <span>Pick a Date</span>
+                            )}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0">
+                        <Calendar
+                          mode="single"
+                          selected={
+                            field.value
+                              ? new Date(field.value + "T12:00:00")
+                              : undefined
+                          }
+                          onSelect={(date) =>
+                            field.onChange(
+                              date
+                                ? date.toISOString().split("T")[0]
+                                : new Date().toISOString().split("T")[0]
+                            )
+                          }
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <FormField
-            control={form.control}
-            name="clientId"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Client</FormLabel>
-                <Select onValueChange={field.onChange} defaultValue={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select client" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {clients.map((c) => (
-                      <SelectItem key={c.id} value={c.id}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <input type="hidden" name="clientId" value={field.value} />
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="currency"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Currency</FormLabel>
-                <CurrencySelect value={field.value} onValueChange={field.onChange} />
-                <input type="hidden" name="currency" value={field.value} />
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+            {/* From / To */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+              <div>
+                <Label className="mb-2 block">From</Label>
+                <div className="space-y-2">
+                  <FormField
+                    control={form.control}
+                    name="fromName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input placeholder="Your Name" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="fromEmail"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input placeholder="Your Email" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="fromAddress"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input placeholder="Your Address" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </div>
 
-        <FormField
-          control={form.control}
-          name="dueDate"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Due Date (days after invoice date)</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  min={0}
-                  {...field}
-                  onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
+              <div>
+                <Label className="mb-2 block">To</Label>
+                <div className="space-y-2">
+                  <FormField
+                    control={form.control}
+                    name="clientId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select a client" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {clients.map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {c.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  {selectedClient && (
+                    <>
+                      <Input value={selectedClient.name} disabled />
+                      <Input value={selectedClient.email ?? ""} disabled />
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Due date + end date */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+              <FormField
+                control={form.control}
+                name="dueDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Due Date (days after invoice)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        {...field}
+                        onChange={(e) =>
+                          field.onChange(parseInt(e.target.value, 10) || 0)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="endDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>End Date (optional)</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            variant="outline"
+                            className="w-full text-left justify-start"
+                          >
+                            <CalendarIcon className="mr-2 size-4" />
+                            {field.value ? (
+                              format(
+                                new Date(field.value + "T12:00:00"),
+                                "PPP"
+                              )
+                            ) : (
+                              <span className="text-muted-foreground">
+                                No end date
+                              </span>
+                            )}
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0">
+                        <Calendar
+                          mode="single"
+                          selected={
+                            field.value
+                              ? new Date(field.value + "T12:00:00")
+                              : undefined
+                          }
+                          onSelect={(date) =>
+                            field.onChange(
+                              date ? date.toISOString().split("T")[0] : ""
+                            )
+                          }
+                          initialFocus
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Invoice items */}
+            <div className="mb-4">
+              <div className="hidden md:grid md:grid-cols-12 gap-4 mb-2 font-medium text-sm">
+                <p className="col-span-6">Description</p>
+                <p className="col-span-2">Quantity</p>
+                <p className="col-span-2">Rate</p>
+                <p className="col-span-2">Amount</p>
+              </div>
+
+              <div className="flex flex-col md:grid md:grid-cols-12 gap-3 md:gap-4">
+                <div className="md:col-span-6">
+                  <Label className="md:hidden mb-1 block text-sm">
+                    Description
+                  </Label>
+                  <FormField
+                    control={form.control}
+                    name="invoiceItemDescription"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Textarea
+                            placeholder="Item name & description"
+                            className="resize-none"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-3 gap-3 md:contents">
+                  <div className="md:col-span-2">
+                    <Label className="md:hidden mb-1 block text-sm">
+                      Quantity
+                    </Label>
+                    <FormField
+                      control={form.control}
+                      name="invoiceItemQuantity"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              placeholder="1"
+                              step="any"
+                              min="0.01"
+                              {...field}
+                              onChange={(e) => {
+                                const val = e.target.value;
+                                field.onChange(
+                                  val === "" ? 0 : parseFloat(val) || 0
+                                );
+                              }}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <div className="md:col-span-2">
+                    <Label className="md:hidden mb-1 block text-sm">Rate</Label>
+                    <FormField
+                      control={form.control}
+                      name="invoiceItemRate"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              placeholder="0.00"
+                              step="any"
+                              min="0.01"
+                              {...field}
+                              onChange={(e) => {
+                                const val = e.target.value;
+                                field.onChange(
+                                  val === "" ? 0 : parseFloat(val) || 0
+                                );
+                              }}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  <div className="md:col-span-2">
+                    <Label className="md:hidden mb-1 block text-sm">
+                      Amount
+                    </Label>
+                    <Input
+                      value={formatCurrency({ amount: localTotal, currency })}
+                      disabled
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Totals */}
+            <div className="flex justify-end mb-6">
+              <div className="w-full sm:w-1/2 md:w-1/3">
+                <div className="flex justify-between py-2 text-sm">
+                  <span>Subtotal</span>
+                  <span>
+                    {formatCurrency({ amount: localTotal, currency })}
+                  </span>
+                </div>
+                <div className="flex justify-between py-2 border-t text-sm">
+                  <span>Total ({currency})</span>
+                  <span className="font-medium underline underline-offset-2">
+                    {formatCurrency({ amount: localTotal, currency })}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Note */}
+            <div className="mb-6">
+              <FormField
+                control={form.control}
+                name="note"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Note</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Add your Note/s right here..."
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-end gap-4">
+              <div className="flex gap-3 w-full sm:w-auto">
+                {onClose && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setShowCancelConfirm(true)}
+                    className="flex-1 sm:flex-none"
+                  >
+                    Cancel
+                  </Button>
+                )}
+                <SubmitButton
+                  text="Create Recurring Invoice"
+                  isLoading={isLoading}
                 />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+              </div>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
 
-        <FormField
-          control={form.control}
-          name="invoiceItemDescription"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Item Description</FormLabel>
-              <FormControl>
-                <Input placeholder="Service description" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <FormField
-            control={form.control}
-            name="invoiceItemQuantity"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Quantity</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    min={0.01}
-                    step="any"
-                    {...field}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      field.onChange(val === "" ? 0 : parseFloat(val) || 0);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="invoiceItemRate"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Rate</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    min={0.01}
-                    step="any"
-                    {...field}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      field.onChange(val === "" ? 0 : parseFloat(val) || 0);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="total"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Total</FormLabel>
-                <FormControl>
-                  <Input type="number" readOnly {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-
-        <FormField
-          control={form.control}
-          name="note"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Note (optional)</FormLabel>
-              <FormControl>
-                <Textarea rows={3} placeholder="Additional notes..." {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <Button type="submit" disabled={isPending} className="w-full">
-          {isPending ? "Creating..." : "Create Recurring Invoice"}
-        </Button>
-      </form>
-    </Form>
+      <ConfirmDialog
+        open={showCancelConfirm}
+        onOpenChange={setShowCancelConfirm}
+        title="Discard changes?"
+        description="Your unsaved changes will be lost. This action cannot be undone."
+        confirmLabel="Discard"
+        cancelLabel="Keep editing"
+        onConfirm={() => onClose?.()}
+      />
+    </Card>
   );
 }

--- a/components/recurring-invoice-form/RecurringInvoiceForm.tsx
+++ b/components/recurring-invoice-form/RecurringInvoiceForm.tsx
@@ -44,6 +44,7 @@ import { recurringInvoiceSchema } from "@/lib/zodSchemas";
 import { createRecurringInvoice } from "@/app/actions/recurringInvoices";
 import { useUser } from "@/components/providers/UserProvider";
 import { toFormData } from "@/lib/toFormData";
+import { useRouter } from "next/navigation";
 import { formatCurrency } from "@/lib/formatCurrency";
 import { Currency } from "@/types";
 
@@ -62,6 +63,7 @@ export function RecurringInvoiceForm({
 }: RecurringInvoiceFormProps) {
   const { firstName, lastName, email, companyName, companyEmail, companyAddress, address } =
     useUser();
+  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [localTotal, setLocalTotal] = useState(0);
@@ -79,9 +81,10 @@ export function RecurringInvoiceForm({
       dueDate: 30,
       invoiceItemDescription: "",
       invoiceItemQuantity: 1,
-      invoiceItemRate: 0,
+      invoiceItemRate: 1,
       total: 0,
       startDate: new Date().toISOString().split("T")[0],
+      note: "",
     },
   });
 
@@ -114,6 +117,13 @@ export function RecurringInvoiceForm({
     };
   }, [form, updateTotal]);
 
+  useEffect(() => {
+    const quantity = form.getValues("invoiceItemQuantity") || 0;
+    const rate = form.getValues("invoiceItemRate") || 0;
+    updateTotal(quantity, rate);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   async function onSubmit(values: FormValues) {
     try {
       setIsLoading(true);
@@ -127,6 +137,7 @@ export function RecurringInvoiceForm({
       }
 
       toast.success("Recurring invoice created");
+      router.refresh();
       onSuccess?.();
       onClose?.();
     } catch (error) {

--- a/components/recurring-invoice-form/RecurringInvoiceForm.tsx
+++ b/components/recurring-invoice-form/RecurringInvoiceForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { Client } from "@prisma/client";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import debounce from "lodash/debounce";
 import { CalendarIcon } from "lucide-react";
 import { format } from "date-fns";
@@ -93,15 +93,13 @@ export function RecurringInvoiceForm({
 
   const currency = form.watch("currency") as Currency;
 
-  const updateTotal = useMemo(
-    () =>
-      debounce((quantity: number, rate: number) => {
-        const calculatedTotal = Math.round(quantity * rate * 100) / 100;
-        setLocalTotal(calculatedTotal);
-        form.setValue("total", calculatedTotal, { shouldValidate: true });
-      }, 300),
-    [form]
-  );
+  const updateTotal = useRef(
+    debounce((quantity: number, rate: number) => {
+      const calculatedTotal = Math.round(quantity * rate * 100) / 100;
+      setLocalTotal(calculatedTotal);
+      form.setValue("total", calculatedTotal, { shouldValidate: true });
+    }, 300)
+  ).current;
 
   useEffect(() => {
     const subscription = form.watch((_, { name }) => {
@@ -115,7 +113,7 @@ export function RecurringInvoiceForm({
       subscription.unsubscribe();
       updateTotal.cancel();
     };
-  }, [form, updateTotal]);
+  }, [form]);
 
   useEffect(() => {
     const quantity = form.getValues("invoiceItemQuantity") || 0;

--- a/components/recurring-invoice-form/RecurringInvoiceForm.tsx
+++ b/components/recurring-invoice-form/RecurringInvoiceForm.tsx
@@ -120,7 +120,9 @@ export function RecurringInvoiceForm({
   useEffect(() => {
     const quantity = form.getValues("invoiceItemQuantity") || 0;
     const rate = form.getValues("invoiceItemRate") || 0;
-    updateTotal(quantity, rate);
+    const calculatedTotal = Math.round(quantity * rate * 100) / 100;
+    setLocalTotal(calculatedTotal);
+    form.setValue("total", calculatedTotal, { shouldValidate: false });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/recurring-invoice-list/RecurringInvoiceList.tsx
+++ b/components/recurring-invoice-list/RecurringInvoiceList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useEffect, useTransition } from "react";
 import { RecurringInvoice, Client } from "@prisma/client";
 import { format } from "date-fns";
 import { MoreHorizontal, Pause, Play, Trash2 } from "lucide-react";
@@ -39,6 +39,10 @@ const INTERVAL_LABELS: Record<string, string> = {
 export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
   const [list, setList] = useState(items);
   const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setList(items);
+  }, [items]);
 
   function handleToggle(id: string) {
     startTransition(async () => {


### PR DESCRIPTION
Restructures RecurringInvoiceForm to match InvoiceForm visually:
- Wraps in Card/CardContent like InvoiceForm
- Adds "Recurring" badge + invoice name header row
- Meta grid: Recurrence | Currency | Start Date (calendar picker)
- From/To two-column section with client select and preview
- Due date + end date (calendar picker) side by side
- Table-style items section with Description/Quantity/Rate/Amount columns
- Subtotal/Total summary block
- Note field
- Cancel (with discard confirm) + submit actions
- Switches from useActionState/hidden-inputs to handleSubmit + toFormData
  for consistency with InvoiceForm
- Updates RecurringInvoiceDialog: passes onClose, widens to max-w-4xl

https://claude.ai/code/session_01SWSqdG3Dkx4gFJeE2azVtV