### PR TITLE
feat(mobile): responsive UX refactor for all key views

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -124,7 +124,7 @@ export default async function AdminUsersPage() {
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[360px] text-sm">
+            <table className="w-full text-sm">
               <thead>
                 <tr className="border-b text-muted-foreground text-left">
                   <th className="pb-3 pr-4 font-medium">Name</th>

--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -17,7 +17,7 @@ export default function AuthError() {
       <div className="absolute inset-0 -z-10 h-full w-full bg-white bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]">
         <div className="absolute bottom-0 left-0 right-0 top-0 bg-[radial-gradient(circle_500px_at_50%_200px,#FFF0F0,transparent)]"></div>
       </div>
-      <Card className="w-[380px] px-5">
+      <Card className="w-full max-w-[380px] px-5">
         <CardHeader className="text-center">
           <div className="mb-4 mx-auto flex size-20 items-center justify-center rounded-full bg-red-100">
             <AlertCircle className="size-12 text-red-500" />

--- a/app/dashboard/clients/[clientId]/page.tsx
+++ b/app/dashboard/clients/[clientId]/page.tsx
@@ -109,12 +109,14 @@ async function ClientDetailPage({ params }: { params: Params }) {
       </div>
 
       <Tabs defaultValue="details" className="w-full">
-        <TabsList>
-          <TabsTrigger value="details">Details</TabsTrigger>
-          <TabsTrigger value="addresses">Addresses</TabsTrigger>
-          <TabsTrigger value="contacts">Contact Persons</TabsTrigger>
-          <TabsTrigger value="custom">Custom Fields</TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto pb-1">
+          <TabsList className="w-max">
+            <TabsTrigger value="details">Details</TabsTrigger>
+            <TabsTrigger value="addresses">Addresses</TabsTrigger>
+            <TabsTrigger value="contacts">Contacts</TabsTrigger>
+            <TabsTrigger value="custom">Custom Fields</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="details" className="space-y-4">
           <Card>
@@ -179,7 +181,7 @@ async function ClientDetailPage({ params }: { params: Params }) {
                   {client.invoices.map((invoice) => (
                     <div
                       key={invoice.id}
-                      className="flex items-center justify-between"
+                      className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
                     >
                       <div>
                         <div className="font-medium">{invoice.invoiceName}</div>
@@ -187,7 +189,7 @@ async function ClientDetailPage({ params }: { params: Params }) {
                           {new Date(invoice.date).toLocaleDateString()}
                         </div>
                       </div>
-                      <div className="flex items-center gap-4">
+                      <div className="flex items-center gap-2">
                         <Badge
                           variant={
                             invoice.status === "PAID" ? "default" : "secondary"

--- a/app/dashboard/clients/[clientId]/page.tsx
+++ b/app/dashboard/clients/[clientId]/page.tsx
@@ -81,7 +81,7 @@ async function ClientDetailPage({ params }: { params: Params }) {
 
   return (
     <div className="container mx-auto py-10">
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <div className="flex flex-col items-start gap-2">
           <Link href="/dashboard/clients" className="flex items-center">
             <ArrowLeft className="h-4 w-4 mr-2" />

--- a/app/dashboard/clients/columns.tsx
+++ b/app/dashboard/clients/columns.tsx
@@ -65,7 +65,7 @@ interface ActionCellProps {
   allClients: TableMeta["allClients"];
 }
 
-function ActionCell({ client, allClients }: ActionCellProps) {
+export function ActionCell({ client, allClients }: ActionCellProps) {
   const router = useRouter();
   const clientWithRequiredFields = {
     ...client,

--- a/app/dashboard/clients/data-table.tsx
+++ b/app/dashboard/clients/data-table.tsx
@@ -108,7 +108,51 @@ export function DataTable<TData, TValue>({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div className="rounded-md border overflow-x-auto">
+      {/* Mobile: card list */}
+      <div className="md:hidden space-y-3 mb-4">
+        {table.getRowModel().rows.length ? (
+          table.getRowModel().rows.map((row) => {
+            const nameCell = row.getAllCells().find((c) => c.column.id === "name");
+            const emailCell = row.getAllCells().find((c) => c.column.id === "email");
+            const phoneCell = row.getAllCells().find((c) => c.column.id === "phone");
+            const actionsCell = row.getAllCells().find((c) => c.column.id === "actions");
+            return (
+              <div
+                key={row.id}
+                className="rounded-lg border bg-card p-4 flex flex-col gap-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-sm truncate">
+                    {nameCell
+                      ? flexRender(nameCell.column.columnDef.cell, nameCell.getContext())
+                      : "—"}
+                  </span>
+                  {actionsCell && (
+                    <div className="shrink-0">
+                      {flexRender(actionsCell.column.columnDef.cell, actionsCell.getContext())}
+                    </div>
+                  )}
+                </div>
+                {emailCell && (
+                  <div className="text-sm text-muted-foreground">
+                    {flexRender(emailCell.column.columnDef.cell, emailCell.getContext())}
+                  </div>
+                )}
+                {phoneCell && (
+                  <div className="text-sm text-muted-foreground">
+                    {flexRender(phoneCell.column.columnDef.cell, phoneCell.getContext())}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        ) : (
+          <p className="text-center text-muted-foreground py-8">No clients found.</p>
+        )}
+      </div>
+
+      {/* Desktop: table */}
+      <div className="hidden md:block rounded-md border overflow-x-auto">
         <Table className="min-w-[500px]">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/app/dashboard/clients/data-table.tsx
+++ b/app/dashboard/clients/data-table.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
+import { ActionCell, type Client } from "./columns";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -112,36 +113,24 @@ export function DataTable<TData, TValue>({
       <div className="md:hidden space-y-3 mb-4">
         {table.getRowModel().rows.length ? (
           table.getRowModel().rows.map((row) => {
-            const nameCell = row.getAllCells().find((c) => c.column.id === "name");
-            const emailCell = row.getAllCells().find((c) => c.column.id === "email");
-            const phoneCell = row.getAllCells().find((c) => c.column.id === "phone");
-            const actionsCell = row.getAllCells().find((c) => c.column.id === "actions");
+            const client = row.original as Client;
+            const allClients = (table.options.meta as { allClients: Client[] })?.allClients ?? [];
             return (
               <div
                 key={row.id}
                 className="rounded-lg border bg-card p-4 flex flex-col gap-2"
               >
                 <div className="flex items-center justify-between gap-2">
-                  <span className="font-medium text-sm truncate">
-                    {nameCell
-                      ? flexRender(nameCell.column.columnDef.cell, nameCell.getContext())
-                      : "—"}
-                  </span>
-                  {actionsCell && (
-                    <div className="shrink-0">
-                      {flexRender(actionsCell.column.columnDef.cell, actionsCell.getContext())}
-                    </div>
-                  )}
+                  <span className="font-medium text-sm truncate">{client.name}</span>
+                  <div className="shrink-0">
+                    <ActionCell client={client} allClients={allClients} />
+                  </div>
                 </div>
-                {emailCell && (
-                  <div className="text-sm text-muted-foreground">
-                    {flexRender(emailCell.column.columnDef.cell, emailCell.getContext())}
-                  </div>
+                {client.email && (
+                  <div className="text-sm text-muted-foreground">{client.email}</div>
                 )}
-                {phoneCell && (
-                  <div className="text-sm text-muted-foreground">
-                    {flexRender(phoneCell.column.columnDef.cell, phoneCell.getContext())}
-                  </div>
+                {client.phone && (
+                  <div className="text-sm text-muted-foreground">{client.phone}</div>
                 )}
               </div>
             );

--- a/app/dashboard/recurring-invoices/page.tsx
+++ b/app/dashboard/recurring-invoices/page.tsx
@@ -57,7 +57,7 @@ export default async function RecurringInvoicesPage() {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <CardTitle className="flex items-center gap-2 text-2xl font-bold">
               <RefreshCw className="size-5" /> Recurring Invoices
@@ -66,14 +66,16 @@ export default async function RecurringInvoicesPage() {
               Invoice templates that generate automatically on a schedule.
             </CardDescription>
           </div>
-          <RecurringInvoiceDialog
-            clients={clients}
-            trigger={
-              <Button>
-                <PlusIcon className="mr-2 size-4" /> New Recurring Invoice
-              </Button>
-            }
-          />
+          <div className="shrink-0">
+            <RecurringInvoiceDialog
+              clients={clients}
+              trigger={
+                <Button>
+                  <PlusIcon className="mr-2 size-4" /> New Recurring Invoice
+                </Button>
+              }
+            />
+          </div>
         </div>
       </CardHeader>
       <CardContent>

--- a/app/verify/page.tsx
+++ b/app/verify/page.tsx
@@ -24,7 +24,7 @@ const Verify = async () => {
       <div className="absolute inset-0 -z-10 h-full w-full bg-white bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]">
         <div className="absolute bottom-0 left-0 right-0 top-0 bg-[radial-gradient(circle_500px_at_50%_200px,#C9EBFF,transparent)]"></div>
       </div>
-      <Card className="w-[380px] px-5">
+      <Card className="w-full max-w-[380px] px-5">
         <CardHeader className="text-center">
           <div className="mb-4 mx-auto flex size-20 items-center justify-center rounded-full bg-blue-100">
             <Mail className="size-12 text-blue-500" />

--- a/components/graph/Graph.tsx
+++ b/components/graph/Graph.tsx
@@ -112,13 +112,32 @@ export function Graph({ data, chartType = "line", currency = "USD" }: GraphProps
     );
   }
 
+  const yAxisProps = {
+    width: 52,
+    tick: { fontSize: 11 },
+    tickFormatter: (v: number) =>
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }).format(v),
+  };
+
+  const xAxisProps = {
+    dataKey: "date" as const,
+    tick: { fontSize: 11 },
+    interval: "preserveStartEnd" as const,
+    tickFormatter: (v: number) => format(v, "MMM d"),
+  };
+
   if (chartType === "bar") {
     return (
-      <ChartContainer config={chartConfig} className="min-h-[300px]">
+      <ChartContainer config={chartConfig} className="min-h-[300px] w-full">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={data}>
-            <XAxis dataKey="date" tickFormatter={(v) => format(v, "MMM d")} />
-            <YAxis />
+          <BarChart data={data} margin={{ left: 0, right: 8, top: 4, bottom: 0 }}>
+            <XAxis {...xAxisProps} />
+            <YAxis {...yAxisProps} />
             <ChartTooltip content={({ active, payload }) => (
               <AmountTooltip active={active} payload={payload as { payload: DataPoint; value: number }[]} currency={currency} />
             )} />
@@ -130,11 +149,11 @@ export function Graph({ data, chartType = "line", currency = "USD" }: GraphProps
   }
 
   return (
-    <ChartContainer config={chartConfig} className="min-h-[300px]">
+    <ChartContainer config={chartConfig} className="min-h-[300px] w-full">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <XAxis dataKey="date" tickFormatter={(value) => format(value, "MMM d")} />
-          <YAxis />
+        <LineChart data={data} margin={{ left: 0, right: 8, top: 4, bottom: 0 }}>
+          <XAxis {...xAxisProps} />
+          <YAxis {...yAxisProps} />
           <ChartTooltip content={({ active, payload }) => (
             <AmountTooltip active={active} payload={payload as { payload: DataPoint; value: number }[]} currency={currency} />
           )} />

--- a/components/invoice-dialog/ViewInvoiceDialog.tsx
+++ b/components/invoice-dialog/ViewInvoiceDialog.tsx
@@ -68,7 +68,7 @@ export function ViewInvoiceDialog({
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="w-full sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Invoice Details</DialogTitle>
           <DialogDescription>
@@ -137,14 +137,39 @@ export function ViewInvoiceDialog({
 
           <Card className="mt-8">
             <CardContent className="pt-6">
-              <div className="grid grid-cols-12 gap-4 mb-2 font-medium">
+              {/* Mobile: stacked item layout */}
+              <div className="sm:hidden flex flex-col gap-3 mb-4 text-sm">
+                <div className="whitespace-pre-line">
+                  {invoice.invoiceItemDescription}
+                </div>
+                <div className="flex gap-6 text-muted-foreground">
+                  <span>Qty: {invoice.invoiceItemQuantity}</span>
+                  <span>
+                    Rate:{" "}
+                    {formatCurrency({
+                      amount: invoice.invoiceItemRate,
+                      currency: invoice.currency as Currency,
+                    })}
+                  </span>
+                  <span>
+                    Amount:{" "}
+                    {formatCurrency({
+                      amount: invoice.total,
+                      currency: invoice.currency as Currency,
+                    })}
+                  </span>
+                </div>
+              </div>
+
+              {/* Desktop: 12-col grid */}
+              <div className="hidden sm:grid grid-cols-12 gap-4 mb-2 font-medium">
                 <p className="col-span-6">Description</p>
                 <p className="col-span-2">Quantity</p>
                 <p className="col-span-2">Rate</p>
                 <p className="col-span-2">Amount</p>
               </div>
 
-              <div className="grid grid-cols-12 gap-4 mb-4">
+              <div className="hidden sm:grid grid-cols-12 gap-4 mb-4">
                 <div className="col-span-6">
                   <div className="whitespace-pre-line">
                     {invoice.invoiceItemDescription}
@@ -166,7 +191,7 @@ export function ViewInvoiceDialog({
               </div>
 
               <div className="flex justify-end">
-                <div className="w-1/3">
+                <div className="w-full sm:w-1/2 md:w-1/3">
                   <div className="flex justify-between py-2">
                     <span>Subtotal</span>
                     <span>

--- a/components/invoice-dialog/ViewInvoiceDialog.tsx
+++ b/components/invoice-dialog/ViewInvoiceDialog.tsx
@@ -68,7 +68,7 @@ export function ViewInvoiceDialog({
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="w-full sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="w-full max-w-none sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Invoice Details</DialogTitle>
           <DialogDescription>
@@ -142,7 +142,7 @@ export function ViewInvoiceDialog({
                 <div className="whitespace-pre-line">
                   {invoice.invoiceItemDescription}
                 </div>
-                <div className="flex gap-6 text-muted-foreground">
+                <div className="flex flex-wrap gap-x-6 gap-y-1 text-muted-foreground">
                   <span>Qty: {invoice.invoiceItemQuantity}</span>
                   <span>
                     Rate:{" "}

--- a/components/invoice-form/InvoiceItemsSection.tsx
+++ b/components/invoice-form/InvoiceItemsSection.tsx
@@ -63,8 +63,8 @@ export function InvoiceItemsSection({
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-3 md:contents">
-            <div className="md:col-span-2">
+          <div className="grid grid-cols-3 gap-2 md:contents">
+            <div className="md:col-span-2 min-w-0">
               <Label className="md:hidden mb-1 block text-sm">Quantity</Label>
               <FormField
                 control={form.control}
@@ -92,7 +92,7 @@ export function InvoiceItemsSection({
               />
             </div>
 
-            <div className="md:col-span-2">
+            <div className="md:col-span-2 min-w-0">
               <Label className="md:hidden mb-1 block text-sm">Rate</Label>
               <FormField
                 control={form.control}
@@ -120,7 +120,7 @@ export function InvoiceItemsSection({
               />
             </div>
 
-            <div className="md:col-span-2">
+            <div className="md:col-span-2 min-w-0">
               <Label className="md:hidden mb-1 block text-sm">Amount</Label>
               <Input
                 value={formatCurrency({ amount: localTotal, currency })}

--- a/components/invoice-list/InvoiceList.tsx
+++ b/components/invoice-list/InvoiceList.tsx
@@ -41,33 +41,50 @@ async function getData(userId: string) {
 
 function InvoiceListSkeleton() {
   return (
-    <div className="rounded-md border">
-      {/* Table header */}
-      <div className="border-b">
-        <div className="grid grid-cols-6 p-4">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-24 ml-auto" />
-        </div>
+    <>
+      {/* Mobile skeleton */}
+      <div className="md:hidden space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="rounded-lg border p-4 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-4 w-32" />
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          </div>
+        ))}
       </div>
 
-      {/* Table rows */}
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="border-b">
+      {/* Desktop skeleton */}
+      <div className="hidden md:block rounded-md border">
+        <div className="border-b">
           <div className="grid grid-cols-6 p-4">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-4 w-32" />
             <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-8 w-20 ml-auto" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-24 ml-auto" />
           </div>
         </div>
-      ))}
-    </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="border-b">
+            <div className="grid grid-cols-6 p-4">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-8 w-20 ml-auto" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -87,45 +104,82 @@ export async function InvoiceList({ emptyButton }: { emptyButton?: ReactNode }) 
           href="/dashboard/invoices/create"
         />
       ) : (
-        <div className="overflow-x-auto -mx-1">
-          <Table className="min-w-[540px]">
-            <TableHeader>
-              <TableRow>
-                <TableHead>Invoice ID</TableHead>
-                <TableHead>Customer</TableHead>
-                <TableHead>Amount</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Date</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.map((invoice) => (
-                <TableRow key={invoice.id}>
-                  <TableCell>#{invoice.invoiceNumber}</TableCell>
-                  <TableCell>{invoice.client?.name || "—"}</TableCell>
-                  <TableCell>
+        <>
+          {/* Mobile: card list */}
+          <div className="md:hidden space-y-3">
+            {data.map((invoice) => (
+              <div
+                key={invoice.id}
+                className="rounded-lg border bg-card p-4 flex flex-col gap-2"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">#{invoice.invoiceNumber}</span>
+                  <Badge>{invoice.status}</Badge>
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {invoice.client?.name || "—"}
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span>
                     {formatCurrency({
                       amount: invoice.total,
                       currency: invoice.currency as Currency,
                     })}
-                  </TableCell>
-                  <TableCell>
-                    <Badge>{invoice.status}</Badge>
-                  </TableCell>
-                  <TableCell>
+                  </span>
+                  <span className="text-xs text-muted-foreground">
                     {new Intl.DateTimeFormat("en-US", {
                       dateStyle: "medium",
                     }).format(invoice.createdAt)}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <InvoiceActions invoice={invoice} />
-                  </TableCell>
+                  </span>
+                </div>
+                <div className="flex justify-end pt-1">
+                  <InvoiceActions invoice={invoice} />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Desktop: table */}
+          <div className="hidden md:block overflow-x-auto -mx-1">
+            <Table className="min-w-[540px]">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Invoice ID</TableHead>
+                  <TableHead>Customer</TableHead>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+              </TableHeader>
+              <TableBody>
+                {data.map((invoice) => (
+                  <TableRow key={invoice.id}>
+                    <TableCell>#{invoice.invoiceNumber}</TableCell>
+                    <TableCell>{invoice.client?.name || "—"}</TableCell>
+                    <TableCell>
+                      {formatCurrency({
+                        amount: invoice.total,
+                        currency: invoice.currency as Currency,
+                      })}
+                    </TableCell>
+                    <TableCell>
+                      <Badge>{invoice.status}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {new Intl.DateTimeFormat("en-US", {
+                        dateStyle: "medium",
+                      }).format(invoice.createdAt)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <InvoiceActions invoice={invoice} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </>
       )}
     </>
   );

--- a/components/pricing/PricingSection.tsx
+++ b/components/pricing/PricingSection.tsx
@@ -238,6 +238,9 @@ const PricingSection = ({ isAuthenticated }: { isAuthenticated: boolean }) => {
             <CardDescription>See which plan is right for you</CardDescription>
           </CardHeader>
           <CardContent>
+            <p className="text-xs text-center text-muted-foreground mb-3 sm:hidden">
+              ← Scroll to compare all plans →
+            </p>
             <table className="w-full min-w-[600px] table-fixed">
               <colgroup>
                 <col className="w-[220px]" />

--- a/components/recent-invoices/RecentInvoices.tsx
+++ b/components/recent-invoices/RecentInvoices.tsx
@@ -65,11 +65,11 @@ export default function RecentInvoices({
                   {item.client?.name?.slice(0, 2) || "?"}
                 </AvatarFallback>
               </Avatar>
-              <div className="ml-4 space-y-1">
-                <p className="text-sm font-medium leading-none">
+              <div className="ml-4 space-y-1 min-w-0 flex-1">
+                <p className="text-sm font-medium leading-none truncate">
                   {item.client?.name || "—"}
                 </p>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-muted-foreground truncate">
                   {item.client?.email || "—"}
                 </p>
               </div>

--- a/components/recurring-invoice-form/RecurringInvoiceForm.tsx
+++ b/components/recurring-invoice-form/RecurringInvoiceForm.tsx
@@ -451,8 +451,8 @@ export function RecurringInvoiceForm({
                   />
                 </div>
 
-                <div className="grid grid-cols-3 gap-3 md:contents">
-                  <div className="md:col-span-2">
+                <div className="grid grid-cols-3 gap-2 md:contents">
+                  <div className="md:col-span-2 min-w-0">
                     <Label className="md:hidden mb-1 block text-sm">
                       Quantity
                     </Label>
@@ -482,7 +482,7 @@ export function RecurringInvoiceForm({
                     />
                   </div>
 
-                  <div className="md:col-span-2">
+                  <div className="md:col-span-2 min-w-0">
                     <Label className="md:hidden mb-1 block text-sm">Rate</Label>
                     <FormField
                       control={form.control}
@@ -510,7 +510,7 @@ export function RecurringInvoiceForm({
                     />
                   </div>
 
-                  <div className="md:col-span-2">
+                  <div className="md:col-span-2 min-w-0">
                     <Label className="md:hidden mb-1 block text-sm">
                       Amount
                     </Label>

--- a/components/recurring-invoice-list/RecurringInvoiceList.tsx
+++ b/components/recurring-invoice-list/RecurringInvoiceList.tsx
@@ -36,6 +36,44 @@ const INTERVAL_LABELS: Record<string, string> = {
   YEARLY: "Yearly",
 };
 
+interface ItemActionsProps {
+  item: RecurringInvoiceWithClient;
+  isPending: boolean;
+  onToggle: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+function ItemActions({ item, isPending, onToggle, onDelete }: ItemActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" disabled={isPending}>
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onToggle(item.id)}>
+          {item.isActive ? (
+            <>
+              <Pause className="size-4 mr-2" /> Pause
+            </>
+          ) : (
+            <>
+              <Play className="size-4 mr-2" /> Resume
+            </>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => onDelete(item.id)}
+          className="text-destructive"
+        >
+          <Trash2 className="size-4 mr-2" /> Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
   const [list, setList] = useState(items);
   const [isPending, startTransition] = useTransition();
@@ -103,32 +141,12 @@ export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
               {item.endDate && ` · Ends: ${format(new Date(item.endDate), "MMM d, yyyy")}`}
             </div>
             <div className="flex justify-end">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" disabled={isPending}>
-                    <MoreHorizontal className="size-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => handleToggle(item.id)}>
-                    {item.isActive ? (
-                      <>
-                        <Pause className="size-4 mr-2" /> Pause
-                      </>
-                    ) : (
-                      <>
-                        <Play className="size-4 mr-2" /> Resume
-                      </>
-                    )}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => handleDelete(item.id)}
-                    className="text-destructive"
-                  >
-                    <Trash2 className="size-4 mr-2" /> Delete
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+              <ItemActions
+                item={item}
+                isPending={isPending}
+                onToggle={handleToggle}
+                onDelete={handleDelete}
+              />
             </div>
           </div>
         ))}
@@ -153,7 +171,7 @@ export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
               <TableRow key={item.id}>
                 <TableCell className="font-medium">{item.invoiceName}</TableCell>
                 <TableCell>{item.client?.name ?? "—"}</TableCell>
-                <TableCell>{INTERVAL_LABELS[item.interval]}</TableCell>
+                <TableCell>{INTERVAL_LABELS[item.interval] ?? item.interval}</TableCell>
                 <TableCell>{format(new Date(item.nextRunAt), "MMM d, yyyy")}</TableCell>
                 <TableCell>
                   {item.endDate ? format(new Date(item.endDate), "MMM d, yyyy") : "—"}
@@ -164,32 +182,12 @@ export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" disabled={isPending}>
-                        <MoreHorizontal className="size-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => handleToggle(item.id)}>
-                        {item.isActive ? (
-                          <>
-                            <Pause className="size-4 mr-2" /> Pause
-                          </>
-                        ) : (
-                          <>
-                            <Play className="size-4 mr-2" /> Resume
-                          </>
-                        )}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleDelete(item.id)}
-                        className="text-destructive"
-                      >
-                        <Trash2 className="size-4 mr-2" /> Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <ItemActions
+                    item={item}
+                    isPending={isPending}
+                    onToggle={handleToggle}
+                    onDelete={handleDelete}
+                  />
                 </TableCell>
               </TableRow>
             ))}

--- a/components/recurring-invoice-list/RecurringInvoiceList.tsx
+++ b/components/recurring-invoice-list/RecurringInvoiceList.tsx
@@ -81,35 +81,28 @@ export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
   }
 
   return (
-    <div className="overflow-x-auto">
-    <Table className="min-w-[600px]">
-      <TableHeader>
-        <TableRow>
-          <TableHead>Name</TableHead>
-          <TableHead>Client</TableHead>
-          <TableHead>Interval</TableHead>
-          <TableHead>Next Run</TableHead>
-          <TableHead>End Date</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead className="text-right">Actions</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
+    <>
+      {/* Mobile: card list */}
+      <div className="md:hidden space-y-3">
         {list.map((item) => (
-          <TableRow key={item.id}>
-            <TableCell className="font-medium">{item.invoiceName}</TableCell>
-            <TableCell>{item.client?.name ?? "—"}</TableCell>
-            <TableCell>{INTERVAL_LABELS[item.interval]}</TableCell>
-            <TableCell>{format(new Date(item.nextRunAt), "MMM d, yyyy")}</TableCell>
-            <TableCell>
-              {item.endDate ? format(new Date(item.endDate), "MMM d, yyyy") : "—"}
-            </TableCell>
-            <TableCell>
+          <div
+            key={item.id}
+            className="rounded-lg border bg-card p-4 flex flex-col gap-2"
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium">{item.invoiceName}</span>
               <Badge variant={item.isActive ? "default" : "secondary"}>
                 {item.isActive ? "Active" : "Paused"}
               </Badge>
-            </TableCell>
-            <TableCell className="text-right">
+            </div>
+            <div className="text-sm text-muted-foreground">
+              {item.client?.name ?? "—"} · {INTERVAL_LABELS[item.interval] ?? item.interval}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Next: {format(new Date(item.nextRunAt), "MMM d, yyyy")}
+              {item.endDate && ` · Ends: ${format(new Date(item.endDate), "MMM d, yyyy")}`}
+            </div>
+            <div className="flex justify-end">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" size="icon" disabled={isPending}>
@@ -136,11 +129,73 @@ export function RecurringInvoiceList({ items }: RecurringInvoiceListProps) {
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-            </TableCell>
-          </TableRow>
+            </div>
+          </div>
         ))}
-      </TableBody>
-    </Table>
-    </div>
+      </div>
+
+      {/* Desktop: table */}
+      <div className="hidden md:block overflow-x-auto">
+        <Table className="min-w-[600px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Client</TableHead>
+              <TableHead>Interval</TableHead>
+              <TableHead>Next Run</TableHead>
+              <TableHead>End Date</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {list.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell className="font-medium">{item.invoiceName}</TableCell>
+                <TableCell>{item.client?.name ?? "—"}</TableCell>
+                <TableCell>{INTERVAL_LABELS[item.interval]}</TableCell>
+                <TableCell>{format(new Date(item.nextRunAt), "MMM d, yyyy")}</TableCell>
+                <TableCell>
+                  {item.endDate ? format(new Date(item.endDate), "MMM d, yyyy") : "—"}
+                </TableCell>
+                <TableCell>
+                  <Badge variant={item.isActive ? "default" : "secondary"}>
+                    {item.isActive ? "Active" : "Paused"}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" disabled={isPending}>
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => handleToggle(item.id)}>
+                        {item.isActive ? (
+                          <>
+                            <Pause className="size-4 mr-2" /> Pause
+                          </>
+                        ) : (
+                          <>
+                            <Play className="size-4 mr-2" /> Resume
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => handleDelete(item.id)}
+                        className="text-destructive"
+                      >
+                        <Trash2 className="size-4 mr-2" /> Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 }

--- a/components/reports/ClientRevenueTable.tsx
+++ b/components/reports/ClientRevenueTable.tsx
@@ -40,26 +40,47 @@ export function ClientRevenueTable({ data, currency = "USD" }: ClientRevenueTabl
         {data.length === 0 ? (
           <p className="text-center text-muted-foreground py-6">No client data yet.</p>
         ) : (
-          <div className="overflow-x-auto">
-            <Table className="min-w-[360px]">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Client</TableHead>
-                  <TableHead className="text-right">Invoices</TableHead>
-                  <TableHead className="text-right">Revenue</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data.map((row) => (
-                  <TableRow key={row.clientId}>
-                    <TableCell className="font-medium">{row.clientName}</TableCell>
-                    <TableCell className="text-right">{row.invoiceCount}</TableCell>
-                    <TableCell className="text-right">{fmt(row.total)}</TableCell>
+          <>
+            {/* Mobile: card list */}
+            <div className="md:hidden space-y-2">
+              {data.map((row) => (
+                <div
+                  key={row.clientId}
+                  className="flex items-center justify-between rounded-lg border p-3"
+                >
+                  <div>
+                    <p className="font-medium text-sm">{row.clientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {row.invoiceCount} invoice{row.invoiceCount !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                  <span className="font-semibold text-sm">{fmt(row.total)}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop: table */}
+            <div className="hidden md:block overflow-x-auto">
+              <Table className="min-w-[360px]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Client</TableHead>
+                    <TableHead className="text-right">Invoices</TableHead>
+                    <TableHead className="text-right">Revenue</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+                </TableHeader>
+                <TableBody>
+                  {data.map((row) => (
+                    <TableRow key={row.clientId}>
+                      <TableCell className="font-medium">{row.clientName}</TableCell>
+                      <TableCell className="text-right">{row.invoiceCount}</TableCell>
+                      <TableCell className="text-right">{fmt(row.total)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/components/reports/RevenueSummaryCard.tsx
+++ b/components/reports/RevenueSummaryCard.tsx
@@ -48,12 +48,27 @@ export function RevenueSummaryCard({
       <CardContent>
         <ChartContainer
           config={{ total: { label: "Revenue", color: "hsl(var(--primary))" } }}
-          className="min-h-[250px]"
+          className="min-h-[250px] w-full"
         >
           <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={data}>
-              <XAxis dataKey="month" />
-              <YAxis />
+            <BarChart data={data} margin={{ left: 0, right: 8, top: 4, bottom: 0 }}>
+              <XAxis
+                dataKey="month"
+                tick={{ fontSize: 11 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                width={56}
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) =>
+                  new Intl.NumberFormat("en-US", {
+                    style: "currency",
+                    currency,
+                    notation: "compact",
+                    maximumFractionDigits: 1,
+                  }).format(v / 100)
+                }
+              />
               <ChartTooltip
                 content={({ active, payload }) => {
                   if (!active || !payload?.length) return null;


### PR DESCRIPTION
- Convert 4 data tables (invoices, recurring, clients, reports) to
  card-per-row layout on mobile (md:hidden / hidden md:block)
- Fix ViewInvoiceDialog: full-width on mobile, responsive grid-cols-12,
  and w-1/3 total section
- Fix auth/error and verify pages: w-full max-w-[380px] instead of
  fixed w-[380px] that overflows 320px viewports
- Remove min-w-[360px] from admin users table (hidden cols already handle it)
- Add scroll hint text to pricing comparison table on mobile
- Add min-w-0 + tighter gap to invoice/recurring form 3-col input rows
- Fix client detail page header to stack on mobile

https://claude.ai/code/session_01FNb5GKy1F2QGEiYfu2D4cz