### PR TITLE
Show plan usage progress bars in admin user Usage Stats section

### DIFF
--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -140,24 +140,22 @@ export default async function AdminUserDetailPage({
                   ? Math.min(100, Math.round((usage.invoicesThisMonth / usage.invoiceLimit) * 100))
                   : null;
                 const overLimit = pct !== null && pct >= 100;
+                const labelColor = overLimit ? "text-red-600" : pct !== null && pct >= 80 ? "text-yellow-600" : "text-muted-foreground";
                 return (
                   <div className="space-y-1">
                     <div className="flex items-center justify-between text-sm">
                       <span className="flex items-center gap-1.5"><FileText className="size-3.5 text-blue-600" /> Invoices</span>
-                      <span className={overLimit ? "text-red-600 font-medium" : "text-muted-foreground"}>
-                        {usage.invoicesThisMonth}
-                        {usage.invoiceLimit !== null ? ` / ${usage.invoiceLimit}` : " / ∞"}
+                      <span className={`font-medium tabular-nums ${labelColor}`}>
+                        {usage.invoicesThisMonth}{usage.invoiceLimit !== null ? ` / ${usage.invoiceLimit}` : " / ∞"}
+                        {pct !== null && <span className="ml-1.5 text-xs">({pct}%)</span>}
                       </span>
                     </div>
                     {pct !== null ? (
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 flex-1 rounded-full bg-muted overflow-hidden">
-                          <div
-                            className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-blue-500"}`}
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                        <span className={`text-xs font-medium w-9 text-right tabular-nums ${overLimit ? "text-red-600" : pct >= 80 ? "text-yellow-600" : "text-muted-foreground"}`}>{pct}%</span>
+                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-blue-500"}`}
+                          style={{ width: `${pct}%` }}
+                        />
                       </div>
                     ) : (
                       <p className="text-xs text-muted-foreground">Unlimited</p>
@@ -171,24 +169,22 @@ export default async function AdminUserDetailPage({
                   ? Math.min(100, Math.round((usage.emailsThisMonth / usage.emailLimit) * 100))
                   : null;
                 const overLimit = pct !== null && pct >= 100;
+                const labelColor = overLimit ? "text-red-600" : pct !== null && pct >= 80 ? "text-yellow-600" : "text-muted-foreground";
                 return (
                   <div className="space-y-1">
                     <div className="flex items-center justify-between text-sm">
                       <span className="flex items-center gap-1.5"><Send className="size-3.5 text-orange-600" /> Emails</span>
-                      <span className={overLimit ? "text-red-600 font-medium" : "text-muted-foreground"}>
-                        {usage.emailsThisMonth}
-                        {usage.emailLimit !== null ? ` / ${usage.emailLimit}` : " / ∞"}
+                      <span className={`font-medium tabular-nums ${labelColor}`}>
+                        {usage.emailsThisMonth}{usage.emailLimit !== null ? ` / ${usage.emailLimit}` : " / ∞"}
+                        {pct !== null && <span className="ml-1.5 text-xs">({pct}%)</span>}
                       </span>
                     </div>
                     {pct !== null ? (
-                      <div className="flex items-center gap-2">
-                        <div className="h-2 flex-1 rounded-full bg-muted overflow-hidden">
-                          <div
-                            className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-orange-500"}`}
-                            style={{ width: `${pct}%` }}
-                          />
-                        </div>
-                        <span className={`text-xs font-medium w-9 text-right tabular-nums ${overLimit ? "text-red-600" : pct >= 80 ? "text-yellow-600" : "text-muted-foreground"}`}>{pct}%</span>
+                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-orange-500"}`}
+                          style={{ width: `${pct}%` }}
+                        />
                       </div>
                     ) : (
                       <p className="text-xs text-muted-foreground">Unlimited</p>

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { adminGetUser, adminGetUserUpgradeRequests } from "@/app/actions/admin";
 import { requireAdmin } from "@/lib/session";
+import { getUserUsage } from "@/lib/usage";
 import { AdminUserActions } from "./AdminUserActions";
 
 export default async function AdminUserDetailPage({
@@ -20,10 +21,11 @@ export default async function AdminUserDetailPage({
   params: Promise<{ userId: string }>;
 }) {
   const { userId } = await params;
-  const [session, user, upgradeRequests] = await Promise.all([
+  const [session, user, upgradeRequests, usage] = await Promise.all([
     requireAdmin(),
     adminGetUser(userId),
     adminGetUserUpgradeRequests(userId),
+    getUserUsage(userId),
   ]);
 
   if (!user) notFound();
@@ -104,27 +106,90 @@ export default async function AdminUserDetailPage({
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Usage Stats</CardTitle>
+            <CardDescription>All-time totals and this month&apos;s plan usage</CardDescription>
           </CardHeader>
-          <CardContent className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
-              <FileText className="size-6 text-blue-600 mb-1" />
-              <span className="text-2xl font-bold">{user._count.invoices}</span>
-              <span className="text-xs text-muted-foreground">Invoices</span>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
+                <FileText className="size-6 text-blue-600 mb-1" />
+                <span className="text-2xl font-bold">{user._count.invoices}</span>
+                <span className="text-xs text-muted-foreground">Invoices</span>
+              </div>
+              <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
+                <Users className="size-6 text-green-600 mb-1" />
+                <span className="text-2xl font-bold">{user._count.clients}</span>
+                <span className="text-xs text-muted-foreground">Clients</span>
+              </div>
+              <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
+                <RefreshCw className="size-6 text-purple-600 mb-1" />
+                <span className="text-2xl font-bold">{user._count.recurringInvoices}</span>
+                <span className="text-xs text-muted-foreground">Recurring</span>
+              </div>
+              <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
+                <Send className="size-6 text-orange-600 mb-1" />
+                <span className="text-2xl font-bold">{user._count.emailLogs}</span>
+                <span className="text-xs text-muted-foreground">Emails Sent</span>
+              </div>
             </div>
-            <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
-              <Users className="size-6 text-green-600 mb-1" />
-              <span className="text-2xl font-bold">{user._count.clients}</span>
-              <span className="text-xs text-muted-foreground">Clients</span>
-            </div>
-            <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
-              <RefreshCw className="size-6 text-purple-600 mb-1" />
-              <span className="text-2xl font-bold">{user._count.recurringInvoices}</span>
-              <span className="text-xs text-muted-foreground">Recurring</span>
-            </div>
-            <div className="flex flex-col items-center justify-center rounded-lg bg-muted/50 p-4">
-              <Send className="size-6 text-orange-600 mb-1" />
-              <span className="text-2xl font-bold">{user._count.emailLogs}</span>
-              <span className="text-xs text-muted-foreground">Emails Sent</span>
+
+            <div className="border-t pt-4 space-y-3">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">This Month&apos;s Plan Usage</p>
+              {/* Invoices this month */}
+              {(() => {
+                const pct = usage.invoiceLimit
+                  ? Math.min(100, Math.round((usage.invoicesThisMonth / usage.invoiceLimit) * 100))
+                  : null;
+                const overLimit = pct !== null && pct >= 100;
+                return (
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center gap-1.5"><FileText className="size-3.5 text-blue-600" /> Invoices</span>
+                      <span className={overLimit ? "text-red-600 font-medium" : "text-muted-foreground"}>
+                        {usage.invoicesThisMonth}
+                        {usage.invoiceLimit !== null ? ` / ${usage.invoiceLimit}` : " / ∞"}
+                      </span>
+                    </div>
+                    {pct !== null ? (
+                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-blue-500"}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">Unlimited</p>
+                    )}
+                  </div>
+                );
+              })()}
+              {/* Emails this month */}
+              {(() => {
+                const pct = usage.emailLimit
+                  ? Math.min(100, Math.round((usage.emailsThisMonth / usage.emailLimit) * 100))
+                  : null;
+                const overLimit = pct !== null && pct >= 100;
+                return (
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="flex items-center gap-1.5"><Send className="size-3.5 text-orange-600" /> Emails</span>
+                      <span className={overLimit ? "text-red-600 font-medium" : "text-muted-foreground"}>
+                        {usage.emailsThisMonth}
+                        {usage.emailLimit !== null ? ` / ${usage.emailLimit}` : " / ∞"}
+                      </span>
+                    </div>
+                    {pct !== null ? (
+                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-orange-500"}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">Unlimited</p>
+                    )}
+                  </div>
+                );
+              })()}
             </div>
           </CardContent>
         </Card>

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -150,11 +150,14 @@ export default async function AdminUserDetailPage({
                       </span>
                     </div>
                     {pct !== null ? (
-                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-blue-500"}`}
-                          style={{ width: `${pct}%` }}
-                        />
+                      <div className="flex items-center gap-2">
+                        <div className="h-2 flex-1 rounded-full bg-muted overflow-hidden">
+                          <div
+                            className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-blue-500"}`}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className={`text-xs font-medium w-9 text-right tabular-nums ${overLimit ? "text-red-600" : pct >= 80 ? "text-yellow-600" : "text-muted-foreground"}`}>{pct}%</span>
                       </div>
                     ) : (
                       <p className="text-xs text-muted-foreground">Unlimited</p>
@@ -178,11 +181,14 @@ export default async function AdminUserDetailPage({
                       </span>
                     </div>
                     {pct !== null ? (
-                      <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-orange-500"}`}
-                          style={{ width: `${pct}%` }}
-                        />
+                      <div className="flex items-center gap-2">
+                        <div className="h-2 flex-1 rounded-full bg-muted overflow-hidden">
+                          <div
+                            className={`h-full rounded-full transition-all ${overLimit ? "bg-red-500" : pct >= 80 ? "bg-yellow-500" : "bg-orange-500"}`}
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <span className={`text-xs font-medium w-9 text-right tabular-nums ${overLimit ? "text-red-600" : pct >= 80 ? "text-yellow-600" : "text-muted-foreground"}`}>{pct}%</span>
                       </div>
                     ) : (
                       <p className="text-xs text-muted-foreground">Unlimited</p>


### PR DESCRIPTION
Fetches this month's invoice and email counts via getUserUsage() and
renders them as color-coded progress bars (blue → yellow → red) below
the all-time totals. BUSINESS plan users show "Unlimited" instead of
a bar. Admins can now instantly see how close a user is to their limit.

https://claude.ai/code/session_01Gaz8E7Vo4AF71DtqtvpXV8